### PR TITLE
JWT status route returns application/json

### DIFF
--- a/server/auth_handler.go
+++ b/server/auth_handler.go
@@ -6,10 +6,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/julienschmidt/httprouter"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/julienschmidt/httprouter"
 )
 
 type contextKeyUser string
@@ -154,7 +155,7 @@ func (s *Server) getAuthStatus(w http.ResponseWriter, r *http.Request, ps httpro
 	isValidToken := s.auth.IsValidToken(token)
 	authStatus.IsAuth = isValidToken
 
-	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(authStatus)
 }


### PR DESCRIPTION
I think this should send back application/json rather than text/plain so I don't have to JSON.parse on the front end as there's already a parser within `apiClient` if we just send it back application/json.